### PR TITLE
Implement functionality to move drones, update their positions and update the grid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Text Files
+*.txt
+
 # Distribution / packaging
 .Python
 build/

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -117,6 +117,8 @@ class nepiada(ParallelEnv):
         Returns the observations for each agent
         """
         self.agents = self.possible_agents[:]
+        print("All Agents: ", str(self.agents))
+       
         self.num_moves = 0
 
         # TODO: Reinitialize the grid
@@ -131,8 +133,6 @@ class nepiada(ParallelEnv):
         self.truncations = {agent: False for agent in self.agents}
 
         self.infos = {agent: {} for agent in self.agents}
-        print(set(self.infos.keys()))
-        print(set(self.agents))
 
         self.state = self.observations
 

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -10,14 +10,15 @@ from pettingzoo.utils import parallel_to_aec, aec_to_parallel, wrappers
 from utils.config import Config
 from utils.world import World
 
-def parallel_env(config : Config):
+
+def parallel_env(config: Config):
     """
     The env function often wraps the environment in wrappers by default.
     Converts to AEC API then back to Parallel API since the wrappers are
     only supported in AEC environments.
     """
     internal_render_mode = "human"
-    env = raw_env(render_mode=internal_render_mode, config = config)
+    env = raw_env(render_mode=internal_render_mode, config=config)
     # this wrapper helps error handling for discrete action spaces
     env = wrappers.AssertOutOfBoundsWrapper(env)
     # Provides a wide vareity of helpful user errors
@@ -31,9 +32,10 @@ def raw_env(render_mode=None, config: Config = Config()):
     To support the AEC API, the raw_env() function just uses the from_parallel
     function to convert from a ParallelEnv to an AEC env
     """
-    env = nepiada(render_mode=render_mode, config = config)
+    env = nepiada(render_mode=render_mode, config=config)
     env = parallel_to_aec(env)
     return env
+
 
 class nepiada(ParallelEnv):
     metadata = {"render_modes": ["human"], "name": "nepiada_v1"}
@@ -67,7 +69,9 @@ class nepiada(ParallelEnv):
 
         # Observation space is defined as a N x 2 matrix, where each row corresponds to an agents coordinates.
         # The first column stores the x coordinate and the second column stores the y coordinate
-        return Box(low=0, high=self.config.size, shape=(self.total_agents, 2), dtype=np.int_)
+        return Box(
+            low=0, high=self.config.size, shape=(self.total_agents, 2), dtype=np.int_
+        )
 
     # Action space should be defined here.
     @functools.lru_cache(maxsize=None)
@@ -89,7 +93,6 @@ class nepiada(ParallelEnv):
         elif self.render_mode == "human":
             # Temporary to print grid for debug purposes until we have a better way to render.
             self.world.grid.print_grid()
-
 
     def observe(self, agent):
         """
@@ -118,7 +121,7 @@ class nepiada(ParallelEnv):
         """
         self.agents = self.possible_agents[:]
         print("All Agents: ", str(self.agents))
-       
+
         self.num_moves = 0
 
         # TODO: Reinitialize the grid
@@ -171,7 +174,7 @@ class nepiada(ParallelEnv):
 
         if self.render_mode == "human":
             self.render()
-        
+
         return observations, rewards, terminations, truncations, infos
 
     def move_drones(self, actions):
@@ -199,4 +202,3 @@ class nepiada(ParallelEnv):
             if status == -2:
                 # Drone collided with another drone
                 pass
-        

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -148,10 +148,8 @@ class nepiada(ParallelEnv):
         - infos
         dicts where each dict looks like {agent_1: item_1, agent_2: item_2}
         """
-        # If a user passes in actions with no agents, then just return empty observations, etc.
-        if not actions:
-            self.agents = []
-            return {}, {}, {}, {}, {}
+        # Assert that number of actions are equal to the number of agents
+        assert len(actions) == len(self.agents)
 
         self.move_drones(actions)
         # We should update the rewards here, for now, we will just set everything to 0

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -10,6 +10,8 @@ from pettingzoo.utils import parallel_to_aec, aec_to_parallel, wrappers
 from utils.config import Config
 from utils.world import World
 
+possible_moves = {0 : "STAY", 1 : "UP", 2 : "DOWN", 3 : "LEFT", 4 : "RIGHT"}
+
 def parallel_env(config : Config):
     """
     The env function often wraps the environment in wrappers by default.

--- a/src/nepiada/utils/agent.py
+++ b/src/nepiada/utils/agent.py
@@ -16,7 +16,7 @@ class Entity:  # physical/external base state of all entities
         self.p_vel = None
 
 class Agent(Entity):  # properties of agent entities
-    def __init__(self, type):
+    def __init__(self, type, uid):
         super().__init__()
 
         print("Agent has been initialized")
@@ -33,4 +33,6 @@ class Agent(Entity):  # properties of agent entities
         # cannot observe the world
         self.blind = False
 
+        # unique agent id as int
+        self.uid = uid
     

--- a/src/nepiada/utils/agent.py
+++ b/src/nepiada/utils/agent.py
@@ -1,11 +1,14 @@
 import numpy as np
+import itertools
 from enum import Enum
 from utils.config import Config
+
 
 # Types of agents
 class AgentType(Enum):
     TRUTHFUL = 1
     ADVERSARIAL = 2
+
 
 class Entity:  # physical/external base state of all entities
     def __init__(self):
@@ -15,11 +18,12 @@ class Entity:  # physical/external base state of all entities
         # physical velocity - we can probably add this information when communicating with other agents
         self.p_vel = None
 
-class Agent(Entity):  # properties of agent entities
-    def __init__(self, type, uid):
-        super().__init__()
 
-        print("Agent with uid " + str(uid) + " has been initialized")
+class Agent(Entity):  # properties of agent entities
+    agent_id = itertools.count(1)
+
+    def __init__(self, type):
+        super().__init__()
 
         # Randomize the position of the agent, p_pos is stored as [x_coor, y_coor] of the agent
         self.p_pos = np.random.randint(low=0, high=Config.size, size=2)
@@ -34,5 +38,6 @@ class Agent(Entity):  # properties of agent entities
         self.blind = False
 
         # unique agent id as int
-        self.uid = uid
-    
+        self.uid = next(Agent.agent_id)
+
+        print("Agent with uid " + str(self.uid) + " has been initialized")

--- a/src/nepiada/utils/agent.py
+++ b/src/nepiada/utils/agent.py
@@ -19,7 +19,7 @@ class Agent(Entity):  # properties of agent entities
     def __init__(self, type, uid):
         super().__init__()
 
-        print("Agent has been initialized")
+        print("Agent with uid " + str(uid) + " has been initialized")
 
         # Randomize the position of the agent, p_pos is stored as [x_coor, y_coor] of the agent
         self.p_pos = np.random.randint(low=0, high=Config.size, size=2)

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -4,4 +4,6 @@ class Config:
     num_adversarial_agents: int = 2
     obs_radius: int = 20
     iterations: int = 100
+    # Possible moves for each drone. Key is the action, value is the (dx, dy) tuple
+    # Default: 0 - stay, 1 - up, 2 - down, 3 - left, 4 - right
     possible_moves : {int : int} = {0 : (0, 0), 1 : (0, 1), 2 : (0, -1), 3 : (-1, 0), 4 : (1, 0)}

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -4,3 +4,4 @@ class Config:
     num_adversarial_agents: int = 2
     obs_radius: int = 20
     iterations: int = 100
+    possible_moves : {int : int} = {0 : (0, 0), 1 : (0, 1), 2 : (0, -1), 3 : (-1, 0), 4 : (1, 0)}

--- a/src/nepiada/utils/grid.py
+++ b/src/nepiada/utils/grid.py
@@ -35,15 +35,23 @@ class Grid():
         x_coord = agent.p_pos[0]
         y_coord = agent.p_pos[1]
 
+        # Check if the move is to stay in the same position, if so just return
+        dx = self.config.possible_moves[action][0]
+        dy = self.config.possible_moves[action][1]
+
+        if dx == 0 and dy == 0:
+            return 0
+
         # Get the new position of the agent
-        new_x_coord = x_coord + self.config.possible_moves[action][0]
-        new_y_coord = y_coord + self.config.possible_moves[action][1]
+        new_x_coord = x_coord + dx
+        new_y_coord = y_coord + dy
+
         # Check if the new position is valid
         if new_x_coord < 0 or new_x_coord >= self.dim or new_y_coord < 0 or new_y_coord >= self.dim:
             return -1
 
         # Check if the new position is occupied
-        if (x_coord != new_x_coord or y_coord != new_y_coord) and self.state[new_x_coord][new_y_coord] != 0:
+        if self.state[new_x_coord][new_y_coord] != 0:
             return -2
 
         # Update the grid

--- a/src/nepiada/utils/grid.py
+++ b/src/nepiada/utils/grid.py
@@ -3,12 +3,13 @@ from utils.config import Config
 from utils.agent import Agent, AgentType
 
 class Grid():
-    def __init__(self):
+    def __init__(self, config):
         print("Grid has been initialized")
 
-        self.dim = Config.size
+        self.dim = config.size
+        self.config = config
 
-        self.state = np.zeros((self.dim, self.dim))
+        self.state = np.zeros((self.dim, self.dim), dtype=int)
 
         ## An adjacency list for which agent can communicate with each other
         ## Will need to build it from config data
@@ -19,10 +20,42 @@ class Grid():
         self.Go = {}
 
     def update_grid(self, agents):
-        for agent in agents:
+        for id, agent in agents.items():
             x_coord = agent.p_pos[0]
             y_coord = agent.p_pos[1]
-            self.state[x_coord][y_coord] = agent.type.value
+            # commenting this out for now until we have a better way to render
+            # self.state[x_coord][y_coord] = agent.uid if agent.type == AgentType.TRUTHFUL else -agent.uid
+            self.state[x_coord][y_coord] = agent.uid
+    
+    def move_drone(self, agent, action):
+        """
+        Moves drone in corresponding direction, checks for validity of the move
+        """
+        # Get the current position of the agent
+        x_coord = agent.p_pos[0]
+        y_coord = agent.p_pos[1]
+
+        # Get the new position of the agent
+        new_x_coord = x_coord + self.config.possible_moves[action][0]
+        new_y_coord = y_coord + self.config.possible_moves[action][1]
+        # Check if the new position is valid
+        if new_x_coord < 0 or new_x_coord >= self.dim or new_y_coord < 0 or new_y_coord >= self.dim:
+            return -1
+
+        # Check if the new position is occupied
+        if (x_coord != new_x_coord or y_coord != new_y_coord) and self.state[new_x_coord][new_y_coord] != 0:
+            return -2
+
+        # Update the grid
+        self.state[x_coord][y_coord] = 0
+        # commenting this out for now until we have a better way to render
+        # self.state[new_x_coord][new_y_coord] = agent.uid if agent.type == AgentType.TRUTHFUL else -agent.uid
+        self.state[new_x_coord][new_y_coord] = agent.uid
+
+        # Update the agent position
+        agent.p_pos = (new_x_coord, new_y_coord)
+
+        return 0
 
     ## For debug
     def print_grid(self):

--- a/src/nepiada/utils/grid.py
+++ b/src/nepiada/utils/grid.py
@@ -20,7 +20,7 @@ class Grid():
         self.Go = {}
 
     def update_grid(self, agents):
-        for id, agent in agents.items():
+        for _, agent in agents.items():
             x_coord = agent.p_pos[0]
             y_coord = agent.p_pos[1]
             # commenting this out for now until we have a better way to render

--- a/src/nepiada/utils/world.py
+++ b/src/nepiada/utils/world.py
@@ -1,8 +1,8 @@
 from utils.grid import Grid
-from utils.config import Config
 from utils.agent import Agent, AgentType
 
-class World():
+
+class World:
     def __init__(self, config):
         print("World has been initialized")
 
@@ -11,9 +11,11 @@ class World():
         self.agents = {}
         for i in range(self.num_agents):
             if i < config.num_adversarial_agents:
-                self.agents["adversarial_" + str(i)] = Agent(AgentType.ADVERSARIAL, i + 1)
+                self.agents["adversarial_" + str(i)] = Agent(
+                    AgentType.ADVERSARIAL, i + 1
+                )
             else:
-                self.agents["truthful_" + str(i)] = (Agent(AgentType.TRUTHFUL, i + 1))
+                self.agents["truthful_" + str(i)] = Agent(AgentType.TRUTHFUL, i + 1)
 
         # Initialize the Grid
         self.grid = Grid(config)

--- a/src/nepiada/utils/world.py
+++ b/src/nepiada/utils/world.py
@@ -3,28 +3,28 @@ from utils.config import Config
 from utils.agent import Agent, AgentType
 
 class World():
-    def __init__(self):
+    def __init__(self, config):
         print("World has been initialized")
 
         # Initialize the agents
-        self.num_agents = Config.num_good_agents + Config.num_adversarial_agents
-        self.agents = []
+        self.num_agents = config.num_good_agents + config.num_adversarial_agents
+        self.agents = {}
         for i in range(self.num_agents):
-            if i < Config.num_adversarial_agents:
-                self.agents.append(Agent(AgentType.ADVERSARIAL))
+            if i < config.num_adversarial_agents:
+                self.agents["adversarial_" + str(i)] = Agent(AgentType.ADVERSARIAL, i + 1)
             else:
-                self.agents.append(Agent(AgentType.TRUTHFUL))
+                self.agents["truthful_" + str(i)] = (Agent(AgentType.TRUTHFUL, i + 1))
 
         # Initialize the Grid
-        self.grid = Grid()
+        self.grid = Grid(config)
 
         # Update the grid with agents position
         self.grid.update_grid(self.agents)
         self.grid.print_grid()
 
         ## The target where all the drones want to reach
-        self.target_x = Config.size / 2
-        self.target_y = Config.size / 2
+        self.target_x = config.size / 2
+        self.target_y = config.size / 2
 
     # return all entities in the world
     @property

--- a/src/nepiada/utils/world.py
+++ b/src/nepiada/utils/world.py
@@ -11,12 +11,9 @@ class World:
         self.agents = {}
         for i in range(self.num_agents):
             if i < config.num_adversarial_agents:
-                self.agents["adversarial_" + str(i)] = Agent(
-                    AgentType.ADVERSARIAL, i + 1
-                )
+                self.agents["adversarial_" + str(i)] = Agent(AgentType.ADVERSARIAL)
             else:
-                self.agents["truthful_" + str(i)] = Agent(AgentType.TRUTHFUL, i + 1)
-
+                self.agents["truthful_" + str(i)] = Agent(AgentType.TRUTHFUL)
         # Initialize the Grid
         self.grid = Grid(config)
 


### PR DESCRIPTION
This PR adds functionality to NEPIADA to actually move the drones given a set of actions. These changes allow for updating the drone's position, and updating the grid with the new drone positions. It also implements the ability to detect boundary collisions as well as drone-on-drone collisions.

Summary of changes in PR:
1. Update initialization to properly accept configuration objects, and update World to store agents as a dictionary with format {ID: Agent}
2. Initialize possible agents with World's Agent dictionary keys to avoid potential errors with duplicate code
3. Add a field to Agent class to store a unique ID, which is numerical to uniquely identify agents
4. Implement move_drones in environment to move the drones on every step
5. Implement move_drone in grid to take an agent and action and do legality checking as well as updating the grid
6. If drones collide, do a second pass in reverse of the subset of drones that failed to see if the position became available, if so move them.

More info to come...

This PR closes issue #22 and makes progress on #19