### PR TITLE
Implementing rewards for agents

### DIFF
--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -98,12 +98,12 @@ class nepiada(ParallelEnv):
 
             # This is a debugging code
             # TODO: Remove later
-            for agent_name, agent in self.world.agents.items():
-                print(agent_name, " has target neighbours: ")
-                for neighbour, distance in agent.target_neighbour.items():
-                    print(neighbour, distance)
+            # for agent_name, agent in self.world.agents.items():
+            #     print(agent_name, " has target neighbours: ")
+            #     for neighbour, distance in agent.target_neighbour.items():
+            #         print(neighbour, distance)
 
-                print("----------------------")
+            #     print("----------------------")
 
             return
 
@@ -339,7 +339,7 @@ class nepiada(ParallelEnv):
 
                 deviation_from_arrangement += np.sqrt((neighbour_x - agent_x - ideal_x)**2 + (neighbour_y - agent_y - ideal_y)**2)
 
-            # Compute the agent's net reward
-            rewards[agent_name] = (Config.global_reward_weight * global_arrangement_reward) + (Config.local_reward_weight * deviation_from_arrangement)
+            # Compute the agent's net reward, note the negative sign
+            rewards[agent_name] = -((Config.global_reward_weight * global_arrangement_reward) + (Config.local_reward_weight * deviation_from_arrangement))
         
         return rewards

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -336,6 +336,7 @@ class nepiada(ParallelEnv):
                 neighbour_y = neighbour.p_pos[1]
                 ideal_x = ideal_distance[0]
                 ideal_y = ideal_distance[1]
+
                 deviation_from_arrangement += np.sqrt((neighbour_x - agent_x - ideal_x)**2 + (neighbour_y - agent_y - ideal_y)**2)
 
             # Compute the agent's net reward

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -343,10 +343,3 @@ class nepiada(ParallelEnv):
             rewards[agent_name] = (Config.global_reward_weight * global_arrangement_reward) + (Config.local_reward_weight * deviation_from_arrangement)
         
         return rewards
-
-
-
-
-
-
-

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -94,6 +94,16 @@ class nepiada(ParallelEnv):
             # Temporary to print grid for debug purposes until we have a better way to render.
             self.world.grid.render_grid()
             self.world.graph.render_graph(comm=False)
+
+            # This is a debugging code
+            # TODO: Remove later
+            for agent_name, agent in self.world.agents.items():
+                print(agent_name, " has target neighbours: ")
+                for neighbour, distance in agent.target_neighbour.items():
+                    print(neighbour, distance)
+
+                print("----------------------")
+
             return
 
     def observe(self, agent_name):

--- a/src/nepiada/utils/agent.py
+++ b/src/nepiada/utils/agent.py
@@ -47,4 +47,13 @@ class Agent(Entity):  # properties of agent entities
         # This will be populated with the positions that the agent believes itself and other agents to be in.
         self.beliefs = {}
 
+        # This dictionary stores the ideal distance from a drone's neighbour, based on relative_x and relative_y distance
+        self.target_neighbour = {}
+
         print("Agent with uid " + str(self.uid) + " has been initialized")
+
+    def set_target_neighbour(self, neighbour_name, distance):
+        # The distance is a list of [ relative_x_pos, relative_y_pos ]
+        assert len(distance) == 2
+
+        self.target_neighbour[neighbour_name] = distance

--- a/src/nepiada/utils/agent.py
+++ b/src/nepiada/utils/agent.py
@@ -55,5 +55,7 @@ class Agent(Entity):  # properties of agent entities
     def set_target_neighbour(self, neighbour_name, distance):
         # The distance is a list of [ relative_x_pos, relative_y_pos ]
         assert len(distance) == 2
+        assert distance[0] < Config.size and distance[0] > -(Config.size)
+        assert distance[1] < Config.size and distance[1] > -(Config.size)
 
         self.target_neighbour[neighbour_name] = distance

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -32,17 +32,18 @@ class Config:
     num_good_agents : int = 6
     num_adversarial_agents: int = 2
 
-
     # Graph update parameters
     dynamic_obs: bool = True
     obs_radius: int = 5
     full_communication: bool = True
-
     noise = GaussianNoise()
+
 
     # Agent update parameters 
     # Possible moves for each drone. Key is the action, value is the (dx, dy) tuple
     possible_moves : {int : int} = {0 : (0, 0), 1 : (0, 1), 2 : (0, -1), 3 : (-1, 0), 4 : (1, 0)}
     empty_cell : int = -1
+    global_reward_weight : int = 0.5
+    local_reward_weight : int = 0.5
 
 

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -11,6 +11,7 @@ class Config:
     dim: Dimension of the environment
     size: The size of each dimension of the environment
     iterations: Max number of iterations allowed
+    num_agents: Number of agents should NOT be prime to form a rectangular formation
     num_good_agents: Number of truthful agents
     num_adversarial_agents: Number of rogue or un-truthful agents
 
@@ -24,7 +25,11 @@ class Config:
     dim : int = 2
     size : int = 20
     iterations : int = 100
-    num_good_agents : int = 5
+
+    # Agent related parameterss
+    agent_grid_width : int = 4
+    agent_grid_height : int = 2
+    num_good_agents : int = 6
     num_adversarial_agents: int = 2
 
 

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -11,7 +11,9 @@ class Config:
     dim: Dimension of the environment
     size: The size of each dimension of the environment
     iterations: Max number of iterations allowed
-    num_agents: Number of agents should NOT be prime to form a rectangular formation
+    
+    agent_grid_width: Width of the final agent formation, note the goal is to have a rectangular formation
+    agent_grid_height: Height of the final agent formation, note the goal is to have a rectangular formation
     num_good_agents: Number of truthful agents
     num_adversarial_agents: Number of rogue or un-truthful agents
 
@@ -38,12 +40,9 @@ class Config:
     full_communication: bool = True
     noise = GaussianNoise()
 
-
     # Agent update parameters 
     # Possible moves for each drone. Key is the action, value is the (dx, dy) tuple
     possible_moves : {int : int} = {0 : (0, 0), 1 : (0, 1), 2 : (0, -1), 3 : (-1, 0), 4 : (1, 0)}
     empty_cell : int = -1
     global_reward_weight : int = 0.5
     local_reward_weight : int = 0.5
-
-

--- a/src/nepiada/utils/world.py
+++ b/src/nepiada/utils/world.py
@@ -6,16 +6,15 @@ from utils.agent import Agent, AgentType
 
 class World:
     def __init__(self, config):
-        print("World has been initialized")
+        # Check if the number of agents match the agents target size
+        assert config.num_good_agents + config.num_adversarial_agents == config.agent_grid_width * config.agent_grid_height
 
         # Initialize the agents
         self.num_agents = config.num_good_agents + config.num_adversarial_agents
-        self.agents = {}
-        for i in range(self.num_agents):
-            if i < config.num_adversarial_agents:
-                self.agents["adversarial_" + str(i)] = Agent(AgentType.ADVERSARIAL)
-            else:
-                self.agents["truthful_" + str(i)] = Agent(AgentType.TRUTHFUL)
+        self.agents, self.agent_uid_to_name = self.__initialize_agents(self.num_agents, config)
+
+        # Set each agent's adjacent target neighbours
+        self.__initialize_target_neighbours(self.num_agents, config)
         
         # Initialize the Grid
         self.grid = Grid(config)
@@ -33,6 +32,81 @@ class World:
         ## The target where all the drones want to reach
         self.target_x = config.size / 2
         self.target_y = config.size / 2
+
+        print("World has been initialized")
+
+    def __initialize_agents(self, num_agents, config):
+        """
+            This is a private function
+
+            Here we initialize adversarial agents first followed by truthful agents
+            # TODO: They can be randomized by a particular seed
+
+            Returns:
+                agents: Dictionary of agent_name to agent object
+                agent_uid_to_name: Dictionary of agent_uid to agent_name
+        """
+        agents = {}
+        agent_uid_to_name = {}
+        for i in range(num_agents):
+            # Initialize the agent
+            agent_name = ""
+            if i < config.num_adversarial_agents:
+                agent_name = "adversarial_" + str(i)
+                agents[agent_name] = Agent(AgentType.ADVERSARIAL)
+            else:
+                agent_name = "truthful_" + str(i)
+                agents[agent_name] = Agent(AgentType.TRUTHFUL)
+
+            # Map the uid to agent name for later use
+            agent_uid_to_name[i] = agent_name
+
+        return agents, agent_uid_to_name
+
+    def __initialize_target_neighbours(self, num_agents, config):
+        """
+            This is a private function
+
+            The target neighbours for each agent is its left, right, top and bottom agents,
+            if they exist. The agent should try to maintain a unit distance from them.
+
+            Returns: Nothing
+        """
+        assert len(self.agents) != 0
+        assert len(self.agent_uid_to_name) != 0
+
+        for i in range(num_agents):
+            # Get the agent
+            width = config.agent_grid_width
+            height = config.agent_grid_height
+            agent_name = self.agent_uid_to_name[i]
+            agent = self.agents[agent_name]
+
+            # Check the left
+            if (i % width != 0):
+                # Add the target neighbour
+                neighbour_name = self.agent_uid_to_name[i - 1]
+                agent.set_target_neighbour(neighbour_name, [-1, 0])
+
+            # Check the right
+            if ((i + 1) % width != 0):
+                # Add the target neighbour
+                neighbour_name = self.agent_uid_to_name[i + 1]
+                agent.set_target_neighbour(neighbour_name, [1, 0])
+
+            # Check the top
+            if (i // width != 0):
+                # Add the target neighbour
+                neighbour_name = self.agent_uid_to_name[i - width]
+                agent.set_target_neighbour(neighbour_name, [0, 1])
+
+            # Check the bottom
+            if (i // width != height - 1):
+                # Add the target neighbour
+                neighbour_name = self.agent_uid_to_name[i + width]
+                agent.set_target_neighbour(neighbour_name, [0, -1])
+
+        return
 
     def update_graphs(self):
         # Update the graphs based on agent's true current position

--- a/src/tests/env_test.py
+++ b/src/tests/env_test.py
@@ -1,0 +1,22 @@
+import pytest
+import env.nepiada as nepiada
+from tests.test_config import Config
+
+config = Config()
+env = nepiada.parallel_env(config = config)
+
+@pytest.fixture
+def initialize():
+    """
+    This runs before all unit tests
+    """
+    observations, infos = env.reset()
+
+def test_global_rewards():
+    pass
+
+def test_local_rewards():
+    pass
+
+def test_observation_radius_limit():
+    pass

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -11,7 +11,9 @@ class Config:
     dim: Dimension of the environment
     size: The size of each dimension of the environment
     iterations: Max number of iterations allowed
-    num_agents: Number of agents should NOT be prime to form a rectangular formation
+    
+    agent_grid_width: Width of the final agent formation, note the goal is to have a rectangular formation
+    agent_grid_height: Height of the final agent formation, note the goal is to have a rectangular formation
     num_good_agents: Number of truthful agents
     num_adversarial_agents: Number of rogue or un-truthful agents
 
@@ -24,20 +26,19 @@ class Config:
     # Initialization parameters
     dim : int = 2
     size : int = 20
-    iterations : int = 100
+    iterations : int = 5
 
     # Agent related parameterss
-    agent_grid_width : int = 4
+    agent_grid_width : int = 2
     agent_grid_height : int = 2
-    num_good_agents : int = 6
-    num_adversarial_agents: int = 2
+    num_good_agents : int = 3
+    num_adversarial_agents: int = 1
 
     # Graph update parameters
     dynamic_obs: bool = True
-    obs_radius: int = 5
+    obs_radius: int = 10
     full_communication: bool = True
     noise = GaussianNoise()
-
 
     # Agent update parameters 
     # Possible moves for each drone. Key is the action, value is the (dx, dy) tuple
@@ -45,5 +46,4 @@ class Config:
     empty_cell : int = -1
     global_reward_weight : int = 0.5
     local_reward_weight : int = 0.5
-
-
+    

--- a/src/tests/test_config.py
+++ b/src/tests/test_config.py
@@ -1,0 +1,49 @@
+# TODO: Make an enum
+# Default: 0 - stay, 1 - up, 2 - down, 3 - left, 4 - right
+
+from utils.noise import GaussianNoise 
+
+class Config:
+    """ 
+    We allow our environment to be customizable based on the user's requirements.
+    The a brief description of all parameters is given below
+
+    dim: Dimension of the environment
+    size: The size of each dimension of the environment
+    iterations: Max number of iterations allowed
+    num_agents: Number of agents should NOT be prime to form a rectangular formation
+    num_good_agents: Number of truthful agents
+    num_adversarial_agents: Number of rogue or un-truthful agents
+
+    dynamic_obs: Set to true if you wish to update observation graph based on agent's current position
+    obs_radius: The only supported form of dynamic observation is including proximal agents that fall within the observation radius
+    communication_all: If set to True all agents should be able to communicate with all other agents
+
+    possible_moves: The valid actions for each agent
+    """
+    # Initialization parameters
+    dim : int = 2
+    size : int = 20
+    iterations : int = 100
+
+    # Agent related parameterss
+    agent_grid_width : int = 4
+    agent_grid_height : int = 2
+    num_good_agents : int = 6
+    num_adversarial_agents: int = 2
+
+    # Graph update parameters
+    dynamic_obs: bool = True
+    obs_radius: int = 5
+    full_communication: bool = True
+    noise = GaussianNoise()
+
+
+    # Agent update parameters 
+    # Possible moves for each drone. Key is the action, value is the (dx, dy) tuple
+    possible_moves : {int : int} = {0 : (0, 0), 1 : (0, 1), 2 : (0, -1), 3 : (-1, 0), 4 : (1, 0)}
+    empty_cell : int = -1
+    global_reward_weight : int = 0.5
+    local_reward_weight : int = 0.5
+
+


### PR DESCRIPTION
This PR addresses the following and fixes #31 :

- [x] Adds functionality to set their own target neighbours
- [x] Initializes all agents such that they have atmost 4 target neighbours one unit away in left, right, top and bottom direction
- [x] The user can specify the agent grid dimensions from config
- [x] Built the reward function to account for global arrangement and local arrangement fixing #32
    - [x] Global: Average distance of all agents from target
    - [x] Local: Deviation from the local ideal arrangement based on adjacent neighbours 

What needs to be done:
- [ ] Implement high negative rewards for collisions and out-of-boundary moves
- [ ] Rigorous unit testing of the reward functions (and all other functions too)


**Note: The PR should be squash merged**
