### PR TITLE
Implement Dynamic Communication Radius Functionality in NEPIADA

### DIFF
--- a/src/nepiada/baseline.py
+++ b/src/nepiada/baseline.py
@@ -92,6 +92,7 @@ def strip_extreme_values_and_update_beliefs(
         if (
             current_agent not in incoming_messages
             or incoming_messages[current_agent] is None
+            or len(incoming_messages[current_agent].items()) == 0
         ):
             # No incoming messages about this agent, keep previous state
             new_beliefs[current_agent] = curr_beliefs[current_agent]

--- a/src/nepiada/env/nepiada.py
+++ b/src/nepiada/env/nepiada.py
@@ -238,7 +238,7 @@ class nepiada(ParallelEnv):
         Returns the observations for each agent
         """
         self.agents = self.possible_agents[:]
-        print("All Agents: ", str(self.agents))
+        print("NEPIADA INFO: All Agents: ", str(self.agents))
 
         # A list for each agent to show distance from final target
         self.agents_pos = defaultdict(lambda: defaultdict(list))
@@ -270,6 +270,7 @@ class nepiada(ParallelEnv):
 
         self.initialize_beliefs()
 
+        print("NEPIADA INFO: Environment Reset Successful. All Checks Passed.")
         return self.observations, self.infos
 
     def step(self, actions):

--- a/src/nepiada/epsilon_baseline.py
+++ b/src/nepiada/epsilon_baseline.py
@@ -92,6 +92,7 @@ def strip_extreme_values_and_update_beliefs(
         if (
             current_agent not in incoming_messages
             or incoming_messages[current_agent] is None
+            or len(incoming_messages[current_agent].items()) == 0
         ):
           
             # No incoming messages about this agent, keep previous state

--- a/src/nepiada/utils/agent.py
+++ b/src/nepiada/utils/agent.py
@@ -50,7 +50,7 @@ class Agent(Entity):  # properties of agent entities
         # This dictionary stores the ideal distance from a drone's neighbour, based on relative_x and relative_y distance
         self.target_neighbour = {}
 
-        print("Agent with uid " + str(self.uid) + " has been initialized")
+        print("Agent INFO: Agent with uid " + str(self.uid) + " has been initialized")
 
     def set_target_neighbour(self, neighbour_name, distance):
         # The distance is a list of [ relative_x_pos, relative_y_pos ]

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -46,7 +46,7 @@ class Config:
     obs_radius: int = 10
     dynamic_comms: bool = True
     dynamic_comms_radius: int = 15
-    dynamic_comms_enforce_minimum: int = 3
+    dynamic_comms_enforce_minimum: int = 1
     noise = GaussianNoise()
 
     # Agent update parameters

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -41,7 +41,7 @@ class Config:
     dynamic_obs: bool = True
     obs_radius: int = 10
     dynamic_comms: bool = True
-    dynamic_comms_radius: int = 20
+    dynamic_comms_radius: int = 15
     dynamic_comms_enforce_minimum: int = 3
     noise = GaussianNoise()
 

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -40,7 +40,9 @@ class Config:
     # Graph update parameters
     dynamic_obs: bool = True
     obs_radius: int = 10
-    full_communication: bool = True
+    dynamic_comms: bool = True
+    dynamic_comms_radius: int = 20
+    dynamic_comms_enforce_minimum: int = 3
     noise = GaussianNoise()
 
     # Agent update parameters

--- a/src/nepiada/utils/config.py
+++ b/src/nepiada/utils/config.py
@@ -4,6 +4,7 @@
 from utils.noise import GaussianNoise
 from .anim_consts import WIDTH, HEIGHT
 
+
 class Config:
     """
     We allow our environment to be customizable based on the user's requirements.
@@ -20,7 +21,10 @@ class Config:
 
     dynamic_obs: Set to true if you wish to update observation graph based on agent's current position
     obs_radius: The only supported form of dynamic observation is including proximal agents that fall within the observation radius
-    communication_all: If set to True all agents should be able to communicate with all other agents
+
+    dynamic_comms: If set to true, the communication graph is updated based on the agent's current position and the dynamic comms radius. If set to false, the communication graph is static and all agents can communicate with all other agents.
+    dynamic_comms_radius: If dynamic_comms is set to true, the communication graph is updated based on the radius set here
+    dynamic_comms_enforce_minimum: If dynamic_comms is set to true, the communication graph ensures that each agent has at least this many neighbours
 
     possible_moves: The valid actions for each agent
     """
@@ -57,35 +61,37 @@ class Config:
     empty_cell: int = -1
     global_reward_weight: int = 1
     local_reward_weight: int = 1
-    #screen_height: int = 400 
-    #screen_width: int = 400 
+    # screen_height: int = 400
+    # screen_width: int = 400
 
     def __init__(self):
         self._process_screen_size()
-        
-    def _process_screen_size(self): 
-        height = getattr(self,"screen_height",None) 
-        width = getattr(self,"screen_width",None)
-            
-        if width and height: 
-            return 
-        
-        if not height: 
+
+    def _process_screen_size(self):
+        height = getattr(self, "screen_height", None)
+        width = getattr(self, "screen_width", None)
+
+        if width and height:
+            return
+
+        if not height:
             height = HEIGHT * (max(self.size // 30, 0) + 1)
             self.screen_height = height
 
-        if not width: 
+        if not width:
             width = WIDTH * (max(self.size // 30, 0) + 1)
             self.screen_width = width
-        
-        return 
-    
+
+        return
+
+
 # Baseline specific configuration parameters
 class BaselineConfig(Config):
     D: int = 1
 
     def __init__(self):
         super().__init__()
+
 
 # Baseline specific configuration parameters
 class EpsilonBaselineConfig(Config):

--- a/src/nepiada/utils/graphs.py
+++ b/src/nepiada/utils/graphs.py
@@ -13,7 +13,9 @@ class Graph:
         self.agents = agents
         self.global_arrangement_vector = np.array([0, 0]) # The global arrangement vector that tracks the agents distance from the center
         self.dynamic_obs = config.dynamic_obs
-        self.full_communication = config.full_communication
+        self.dynamic_comms = config.dynamic_comms
+        self.dynamic_comms_radius = config.dynamic_comms_radius
+        self.dynamic_comms_enforce_minimum = config.dynamic_comms_enforce_minimum
         self.observation_radius = config.obs_radius
         self.num_agents = config.num_good_agents + config.num_adversarial_agents
         self.obs_arrows = []
@@ -22,9 +24,8 @@ class Graph:
         self.cell_size = cell_size
         self.screen_width = config.screen_width 
         self.screen_height = config.screen_height
-
-        # An adjacency list for which agent can communicate with each other
-        if self.full_communication:
+        ## An adjacency list for which agent can communicate with each other
+        if not self.dynamic_comms:
             all_agents = [agent for agent in self.agents]
             self.comm = {agent: all_agents for agent in self.agents}
         else:

--- a/src/nepiada/utils/graphs.py
+++ b/src/nepiada/utils/graphs.py
@@ -97,10 +97,10 @@ class Graph:
                     )
 
                     # Add the closest agents to the communication graph to reach minimum
-                    for distance, agent_name in distances_to_agents_not_added[
+                    for distance, other_agent_name in distances_to_agents_not_added[
                         :amount_missing
                     ]:
-                        self.comm[agent_name].append(agent_name)
+                        self.comm[agent_name].append(other_agent_name)
         else:
             # Do not update the communication graph, because it has been configured to be static
             pass

--- a/src/nepiada/utils/graphs.py
+++ b/src/nepiada/utils/graphs.py
@@ -120,7 +120,7 @@ class Graph:
                     )
 
                     # Add the closest agents to the communication graph to reach minimum
-                    for distance, other_agent_name in distances_to_agents_not_added[
+                    for _, other_agent_name in distances_to_agents_not_added[
                         :amount_missing
                     ]:
                         self.comm[agent_name].append(other_agent_name)

--- a/src/nepiada/utils/graphs.py
+++ b/src/nepiada/utils/graphs.py
@@ -29,13 +29,15 @@ class Graph:
             all_agents = [agent for agent in self.agents]
             self.comm = {agent: all_agents for agent in self.agents}
 
-            print("Graphs INFO: Static Communication Initialized | All agents can communicate with each other")
+            print("Graphs INFO: Static Communication Graph Initialized | All agents can communicate with each other")
         else:
             self.comm = {agent: [] for agent in self.agents}
-            print(f"Graphs INFO: Dynamic Communication Initialized | Communication Radius: {self.dynamic_comms_radius} units | Enforced minimum number of agents per communication: {self.dynamic_comms_enforce_minimum} agents")
+            print(f"Graphs INFO: Dynamic Communication Graph Initialized | Communication Radius: {self.dynamic_comms_radius} units | Enforced minimum number of agents per communication: {self.dynamic_comms_enforce_minimum} agents")
 
         # An adjacency list for which agent can observe each other
         self.obs = {agent: [] for agent in self.agents}
+        if self.dynamic_obs:
+            print(f"Graphs INFO: Dynamic Observation Graph Initialized | Observation Radius: {self.observation_radius} units")
 
     def _update_obs_graph(self, agents):
         if self.dynamic_obs:

--- a/src/nepiada/utils/graphs.py
+++ b/src/nepiada/utils/graphs.py
@@ -7,7 +7,6 @@ from .anim_consts import *
 
 class Graph:
     def __init__(self, config, agents, screen=None, cell_size=0):
-
         self.dim = config.size
         self.agents = agents
         self.global_arrangement_vector = np.array([0, 0]) # The global arrangement vector that tracks the agents distance from the center
@@ -29,17 +28,30 @@ class Graph:
             all_agents = [agent for agent in self.agents]
             self.comm = {agent: all_agents for agent in self.agents}
 
-            print("Graphs INFO: Static Communication Graph Initialized | All agents can communicate with each other")
+            print(
+                "Graphs INFO: Static Communication Graph Initialized | All agents can communicate with each other"
+            )
         else:
             self.comm = {agent: [] for agent in self.agents}
-            print(f"Graphs INFO: Dynamic Communication Graph Initialized | Communication Radius: {self.dynamic_comms_radius} units | Enforced minimum number of agents per communication: {self.dynamic_comms_enforce_minimum} agents")
+            print(
+                f"Graphs INFO: Dynamic Communication Graph Initialized | Communication Radius: {self.dynamic_comms_radius} units | Enforced minimum number of agents per communication: {self.dynamic_comms_enforce_minimum} agents"
+            )
 
         # An adjacency list for which agent can observe each other
         self.obs = {agent: [] for agent in self.agents}
         if self.dynamic_obs:
-            print(f"Graphs INFO: Dynamic Observation Graph Initialized | Observation Radius: {self.observation_radius} units")
+            print(
+                f"Graphs INFO: Dynamic Observation Graph Initialized | Observation Radius: {self.observation_radius} units"
+            )
 
     def _update_obs_graph(self, agents):
+        """
+        If dynamic observation graph is enabled, this function will update the observation graph based on the current positions of the agents.
+        If static observation graph, this function will do nothing since the observation graph is already configured.
+        
+        params:
+            agents: A dictionary of agents, where the key is the agent's name and the value is the agent object.
+        """
         if self.dynamic_obs:
             # Reset the graph
             self.obs = {agent: [] for agent in agents}
@@ -64,6 +76,15 @@ class Graph:
             pass
 
     def _update_comm_graph(self, agents):
+        """
+        If dynamic communication graph is enabled, this function will update the communication graph based on the current positions of the agents. 
+        It will also enforce a minimum number of agents that can communicate with each other, if the number of agents that can communicate with each other
+        is less than the minimum specified by the configuration.
+        If static communication graph, this function will do nothing since the communication graph is already configured to allow for full communication.
+    
+        params:
+            agents: A dictionary of agents, where the key is the agent's name and the value is the agent object.
+        """
         if self.dynamic_comms:
             # Reset the graph
             self.comm = {agent: [] for agent in agents}

--- a/src/nepiada/utils/graphs.py
+++ b/src/nepiada/utils/graphs.py
@@ -7,7 +7,6 @@ from .anim_consts import *
 
 class Graph:
     def __init__(self, config, agents, screen=None, cell_size=0):
-        print("Graphs have been initialized")
 
         self.dim = config.size
         self.agents = agents
@@ -29,8 +28,11 @@ class Graph:
         if not self.dynamic_comms:
             all_agents = [agent for agent in self.agents]
             self.comm = {agent: all_agents for agent in self.agents}
+
+            print("Graphs INFO: Static Communication Initialized | All agents can communicate with each other")
         else:
             self.comm = {agent: [] for agent in self.agents}
+            print(f"Graphs INFO: Dynamic Communication Initialized | Communication Radius: {self.dynamic_comms_radius} units | Enforced minimum number of agents per communication: {self.dynamic_comms_enforce_minimum} agents")
 
         # An adjacency list for which agent can observe each other
         self.obs = {agent: [] for agent in self.agents}
@@ -90,9 +92,13 @@ class Graph:
                     # Sort the distances to agents not added in ascending order
                     distances_to_agents_not_added.sort(key=lambda x: x[0])
 
-                    # Add the closest agents to the communication graph
+                    amount_missing = self.dynamic_comms_enforce_minimum - len(
+                        self.comm[agent_name]
+                    )
+
+                    # Add the closest agents to the communication graph to reach minimum
                     for distance, agent_name in distances_to_agents_not_added[
-                        : self.dynamic_comms_enforce_minimum
+                        :amount_missing
                     ]:
                         self.comm[agent_name].append(agent_name)
         else:
@@ -257,7 +263,7 @@ class Graph:
         self.clock.tick(FPS)
 
     def reset_graphs(self):
-        if self.full_communication:
+        if not self.dynamic_comms:
             all_agents = [agent for agent in self.agents]
             self.comm = {agent: all_agents for agent in self.agents}
         else:

--- a/src/nepiada/utils/grid.py
+++ b/src/nepiada/utils/grid.py
@@ -6,8 +6,6 @@ from collections import defaultdict
 
 class Grid():
     def __init__(self, config):
-        print("Grid has been initialized")
-
         self.dim = config.size
         self.config = config
         _, self.state_ax = plt.subplots(figsize=(5, 5))
@@ -18,6 +16,8 @@ class Grid():
 
 
         self.uid_to_type = {}
+
+        print("Grid INFO: Grid Initialized")
 
     def save_agent_types(self,agents): 
         for _, agent in agents.items(): 

--- a/src/nepiada/utils/world.py
+++ b/src/nepiada/utils/world.py
@@ -44,6 +44,8 @@ class World:
         self.target_x = config.size / 2
         self.target_y = config.size / 2
 
+        print("World INFO: Simulation World has been initialized")
+
     def _init_pygame(self,width=WIDTH,height=HEIGHT):
         # Initialize Pygame
         pygame.init()


### PR DESCRIPTION
This PR adds support for a dynamic communication radius for our simulation environment, NEPIADA. If the config parameter `dynamic_comms` is set to false, every agent will be able to communicate with every other agent in a static environment as previously implemented. If `dynamic_comms` is set to true, a dynamic comms radius can be set so that only agents within that radius can communicate with each other. In addition, we allow for the enforcement of a minimum number of agents that a given agent must communicate with. If the amount of agents within a given communication radius is less than the enforced minimum, we expand the radius to include the closest X amount of agents to bring the amount up to the minimum.

The dynamic communication radius implementation was designed with runtime in mind. Since we'll need to compute the distance between each agent when communicating, I store all of the distances from a given agent to an "other" agent if that "other" agent is not added to the communication graph. This allows us to sort this list by closest distance and append extra agents if and only if we fail the minimum agent enforcement check.

In short, the PR does the following:
- [x] Implements dynamic communication radius functionality while simultaneously preserving the functionality of having a static, full-communication graph.
- [x]  Adds configuration parameters to enable/disable dynamic communication radius, specify the comms radius, and specify the minimum number of agents that an agent has to communicate with at any given time
- [x] Nit change: Updates info messages that we print to the console to have a uniform structure, and points out the module that is printing it
- [x] Implements functionality to enforce a minimum number of agents that a given agent must communicate with. If after calculating agents within the communication radius we fall below this threshold, we append the nearest agents up until the minimum is reached. This can be disabled by setting the configuration parameter `dynamic_comms_enforce_minimum` to 0.
- [x] Small change to `baseline` and `epsilon_baseline` algorithm to account for potential empty communication messages, as this is possible now.

This PR has been tested with the baseline and epsilon baseline with varying parameters to ensure the communication graph is being updated as intended. The communication graph update function itself has been unit-tested to verify functionality.   

This PR resolves issue #40 